### PR TITLE
ci(semantic-release): switch from git to https protocol

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,7 +3,7 @@
     "master",
     "main"
   ],
-  "repositoryUrl": "git@github.com:karlderkaefer/cdk-notifier.git",
+  "repositoryUrl": "https://github.com/karlderkaefer/cdk-notifier.git",
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
```
The command "git push --dry-run --no-verify https://[secure]@github.com/karlderkaefer/cdk-notifier.git HEAD:main" failed with the error message remote: Support for password authentication was removed on August 13, 2021.
remote: Please see https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-```