### PR TITLE
fix: disable cgo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
               echo "detected windows, adding .exe"
               EXTENSION=".exe"
             fi
-            go build -o "dist/${CIRCLE_PROJECT_REPONAME}_${GOOS}_${GOARCH}${EXTENSION}" -ldflags "-X github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/cmd.Version=${VERSION}"
+            CGO_ENABLED=0 go build -o "dist/${CIRCLE_PROJECT_REPONAME}_${GOOS}_${GOARCH}${EXTENSION}" -ldflags "-X github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/cmd.Version=${VERSION}"
             if [ "$GOOS" == "linux" ] && [ "$GOARCH" == "amd64" ]; then
                ./dist/${CIRCLE_PROJECT_REPONAME}_${GOOS}_${GOARCH} --version
             fi

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.18
+golang 1.20


### PR DESCRIPTION
Since go 1.20 CGo is enabled by default.
But we actually do not require it.

closes #93