### PR TITLE
feat: generate diff for Outputs

### DIFF
--- a/provider/api.go
+++ b/provider/api.go
@@ -48,7 +48,7 @@ func getHeaderTagID(c config.NotifierConfig) string {
 }
 
 func diffHasChanges(log string) bool {
-	regex := regexp.MustCompile(`(?m)(Policy Changes|Resources\n|Statement Changes)`)
+	regex := regexp.MustCompile(`(?m)(Policy Changes|Resources\n|Statement Changes|Outputs\n)`)
 	return regex.MatchString(log)
 }
 

--- a/provider/api_test.go
+++ b/provider/api_test.go
@@ -59,3 +59,11 @@ func TestCreateNotifierService(t *testing.T) {
 	}
 
 }
+
+func Test_DiffOutputChanges(t *testing.T) {
+	assert.True(t, diffHasChanges(`
+Stack OutputStack
+Outputs
+[+] Output output output: {"Value":"","Export":{"Name":"output"}}
+`))
+}


### PR DESCRIPTION
cdk diff for Outputs is not matched by the regex today.