### PR TITLE
feat: Don't truncate PR comments

### DIFF
--- a/provider/api.go
+++ b/provider/api.go
@@ -34,8 +34,8 @@ type Comment struct {
 
 // NotifierService interface for public methods actions required for cdk-notifier
 type NotifierService interface {
-	CreateComment() (*Comment, error)
-	UpdateComment(id int64) (*Comment, error)
+	CreateComment(headerTagID string) ([]*Comment, error)
+	UpdateComment(id int64, i int, headerTagID string) (*Comment, error)
 	DeleteComment(id int64) error
 	SetCommentContent(content string)
 	GetCommentContent() string
@@ -71,54 +71,62 @@ func CreateNotifierService(ctx context.Context, c config.NotifierConfig) (Notifi
 // If the comment already exist the content will be updated.
 // If there are no cdk differences the comment will be deleted depending on DeleteComment config.AppConfig
 func postComment(ns NotifierService, config config.NotifierConfig) (CommentOperation, error) {
-	comment, err := findComment(ns, config)
+	comments, err := findComments(ns, config)
 	if err != nil {
 		return API_COMMENT_NOTHING, err
 	}
-	if comment != nil {
-		// if commit exists but there are no change then delete comment in case DeleteComment is active
-		if config.DeleteComment && !diffHasChanges(ns.GetCommentContent()) {
-			err = ns.DeleteComment(comment.Id)
+	for i, comment := range comments {
+		if comment != nil {
+			// if commit exists but there are no change then delete comment in case DeleteComment is active
+			if config.DeleteComment && !diffHasChanges(ns.GetCommentContent()) {
+				err = ns.DeleteComment(comment.Id)
+				if err != nil {
+					logrus.Error(err)
+					return API_COMMENT_NOTHING, err
+				}
+				logrus.Infof("Deleted comment with id %d and tag id %s because no changes detected", comment.Id, config.TagID)
+			}
+			// if comment exists and there are diff then update existing comment
+			comment, err = ns.UpdateComment(comment.Id, i, getHeaderTagID(config))
 			if err != nil {
 				logrus.Error(err)
 				return API_COMMENT_NOTHING, err
 			}
-			logrus.Infof("Deleted comment with id %d and tag id %s because no changes detected", comment.Id, config.TagID)
-			return API_COMMENT_DELETED, nil
+			logrus.Infof("Updated comment with id %d and tag id %s %v", comment.Id, config.TagID, comment.Link)
 		}
-		// if comment exists and there are diff then update existing comment
-		comment, err = ns.UpdateComment(comment.Id)
-		if err != nil {
-			logrus.Error(err)
-			return API_COMMENT_NOTHING, err
-		}
-		logrus.Infof("Updated comment with id %d and tag id %s %v", comment.Id, config.TagID, comment.Link)
+	}
+
+	if len(comments) > 0 {
 		return API_COMMENT_UPDATED, nil
 	}
+
 	if !diffHasChanges(ns.GetCommentContent()) {
 		logrus.Infof("There is no diff detected for tag id %s. Skip posting diff.", config.TagID)
 		return API_COMMENT_NOTHING, nil
 	}
-	comment, err = ns.CreateComment()
+	comments, err = ns.CreateComment(getHeaderTagID(config))
 	if err != nil {
 		logrus.Error(err)
 		return API_COMMENT_NOTHING, err
 	}
-	logrus.Infof("Created comment with id %d and tag id %s %v", comment.Id, config.TagID, comment.Link)
+	for _, comment := range comments {
+		logrus.Infof("Created comment with id %d and tag id %s %v", comment.Id, config.TagID, comment.Link)
+	}
 	return API_COMMENT_CREATED, nil
 }
 
-// findComment is finding the comment containing the cdk stack id
-func findComment(ns NotifierService, config config.NotifierConfig) (*Comment, error) {
+// findComments finds the comments containing the tag id
+func findComments(ns NotifierService, config config.NotifierConfig) ([]*Comment, error) {
+	var existingComments []*Comment
 	comments, err := ns.ListComments()
 	if err != nil {
 		return nil, err
 	}
-	for _, comment := range comments {
+	for i, comment := range comments {
 		if strings.Contains(comment.Body, getHeaderTagID(config)) {
-			logrus.Debugf("Found existing comment for %s", config.TagID)
-			return &comment, nil
+			logrus.Debugf("Found existing comment id %s for %s", comment.Id, config.TagID)
+			existingComments = append(existingComments, &comments[i])
 		}
 	}
-	return nil, nil
+	return existingComments, nil
 }

--- a/provider/common.go
+++ b/provider/common.go
@@ -1,0 +1,48 @@
+package provider
+
+import (
+	"fmt"
+	"math"
+)
+
+const sepHeader = "Continued from previous comment.\n<details><summary>Show Output</summary>\n\n" +
+	"```diff\n"
+
+const sepFooter = "\n```\n</details>" +
+	"\n<br>\n\n**Warning**: Output length greater than max comment size. Continued in next comment."
+
+func sepHeaderId(headerTagID string) string {
+	return fmt.Sprintf("%s\n", headerTagID) + sepHeader
+}
+
+// SplitComment splits comment into a slice of comments that are under maxSize.
+// It appends sepEnd to all comments that have a following comment.
+// It prepends sepStart to all comments that have a preceding comment.
+func SplitComment(comment string, maxSize int, sepEnd string, sepStart string) []string {
+	if len(comment) <= maxSize {
+		return []string{comment}
+	}
+
+	maxWithSep := maxSize - len(sepEnd) - len(sepStart)
+	var comments []string
+	numComments := int(math.Ceil(float64(len(comment)) / float64(maxWithSep)))
+	for i := 0; i < numComments; i++ {
+		upTo := min(len(comment), (i+1)*maxWithSep)
+		portion := comment[i*maxWithSep : upTo]
+		if i < numComments-1 {
+			portion += sepEnd
+		}
+		if i > 0 {
+			portion = sepStart + portion
+		}
+		comments = append(comments, portion)
+	}
+	return comments
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/transform/transformer.go
+++ b/transform/transformer.go
@@ -1,7 +1,6 @@
 package transform
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"regexp"
@@ -18,7 +17,6 @@ import (
 // 1. Clean any ANSI chars and XTERM color created from cdk diff command
 // 2. Transform additions and removals to markdown diff syntax
 // 3. Create unique message header
-// 4. truncate content if message is longer than GitHub API can handle
 type LogTransformer struct {
 	LogContent                string
 	Logfile                   string
@@ -211,16 +209,6 @@ func (t *LogTransformer) transformDiff() {
 	t.LogContent = strings.Join(transformedLines, "\n")
 }
 
-// truncate to avoid Message:Body is too long (maximum is 65536 characters)
-func (t *LogTransformer) truncate() {
-	runes := bytes.Runes([]byte(t.LogContent))
-	if len(runes) > 65000 {
-		truncated := string(runes[:65000])
-		truncated += "\n...truncated"
-		t.LogContent = truncated
-	}
-}
-
 func (t *LogTransformer) addHeader() {
 	collapsible := false
 	showOverview := false
@@ -281,8 +269,7 @@ func (t *LogTransformer) writeDiffFile() error {
 // 1. Clean any ANSI chars and XTERM color created from cdk diff command
 // 2. Transform additions and removals to markdown diff syntax
 // 3. Create unique message header
-// 4. truncate content if message is longer than GitHub API can handle
-// 5. write diff as file and to stdout when no-post-mode is activated
+// 4. write diff as file and to stdout when no-post-mode is activated
 func (t *LogTransformer) Process() {
 	err := t.readFile()
 	if err != nil {
@@ -291,7 +278,6 @@ func (t *LogTransformer) Process() {
 	t.removeAnsiCode()
 	t.transformDiff()
 	t.addHeader()
-	t.truncate()
 	err = t.writeDiffFile()
 	if err != nil {
 		logrus.Fatal(err)


### PR DESCRIPTION
## What
Terraform refugee here :wave:  - thanks for the tool!

Atlantis style PR comments that are not truncated but roll over onto new comments prefixed/suffixed to let the reviewer know there are continuations.

WIP PR (tests to be addressed/added) to gauge interest in this feature? Implementation could be cleaned up a bit too. Open to suggestions. 

## Why
So PR comments aren't truncated potentially missing changes.

## Testing
I have tested this against GHE, see below. Ironically it seems that GHE can set arbitrary(??) comment limits and while I don't know what ours currently is, it is significantly more than `65536` that github.com sets as the entire comment below _could_ fit into a single comment. Perhaps these could be config rather than hard coded consts.

![image](https://github.com/karlderkaefer/cdk-notifier/assets/3025844/9e1c8020-049c-487b-8da6-ed5dbe2c1607)

Example continuation:

![image](https://github.com/karlderkaefer/cdk-notifier/assets/3025844/26ad8423-d3ab-4779-8014-be470be0eec7)
