### PR TITLE
feat: add suppress hash changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ Any validation is skipped, you only need to set `--log-file` and `--tag-id`.
 Enable this option `--no-post-mode` will write the markdown diff to stdout and a logfile.
 The diff output file is using same path of cdk log file, but is appending `.diff` extension.
 
+## Suppress Hash Changes
+
+See github issue [issue#125](https://github.com/karlderkaefer/cdk-notifier/issues/125).
+In case you want to suppress any hash changes in the diff, you can use the flag `--suppress-hash-changes`.
+For example this would not post a diff for any changes in the hash of the resources [see example](./data/cdk-diff-resources-changes.log).
+
 ## Security
 **Disclaimer**: Consider using on private repositories only.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,14 @@ var rootCmd = &cobra.Command{
 		transformer := transform.NewLogTransformer(appConfig)
 		transformer.Process()
 
+		if appConfig.SuppressHashChanges {
+			logrus.Warnf("Suppressing hash changes detected %d hash changes and %d total changes", transformer.HashChanges, transformer.TotalChanges)
+			if transformer.TotalChanges == transformer.HashChanges {
+				logrus.Warnf("Skipping... because suppress-hash-changes is set and only hash changes detected")
+				return
+			}
+		}
+
 		if appConfig.NoPostMode {
 			return
 		}
@@ -95,6 +103,7 @@ func init() {
 	rootCmd.Flags().Bool("show-overview", false, "[Deprected: use template extended instead] Show Overview are disabled by default. When set to true it will show the number of cdk stacks with diff and  the number of replaced resources in the overview section.")
 	rootCmd.Flags().String("template", "default", "Template to use for comment [default|extended|extendedWithResources]")
 	rootCmd.Flags().String("custom-template", "", "File path or string input to custom template. When set it will override the template flag.")
+	rootCmd.Flags().Bool("suppress-hash-changes", false, "EXPERIMENTAL: when set to true it will ignore changes in hash values")
 
 	// mapping for viper [mapstruct value, flag name]
 	viperMappings := make(map[string]string)
@@ -116,6 +125,7 @@ func init() {
 	viperMappings["CI_SYSTEM"] = "ci"
 	viperMappings["URL"] = "gitlab-url"
 	viperMappings["GITHUB_ENTERPRISE_HOST"] = "github-host"
+	viperMappings["SUPPRESS_HASH_CHANGES"] = "suppress-hash-changes"
 
 	for k, v := range viperMappings {
 		err := viper.BindPFlag(k, rootCmd.Flags().Lookup(v))

--- a/config/app.go
+++ b/config/app.go
@@ -130,9 +130,10 @@ type NotifierConfig struct {
 	NoPostMode      bool   `mapstructure:"NO_POST_MODE"`
 	DisableCollapse bool   `mapstructure:"DISABLE_COLLAPSE"`
 	// TODO deprecated
-	ShowOverview    bool   `mapstructure:"SHOW_OVERVIEW"`
-	Template        string	`mapstructure:"NOTIFIER_TEMPLATE"`
-	CustomTemplate  string `mapstructure:"CUSTOM_TEMPLATE"`
+	ShowOverview        bool   `mapstructure:"SHOW_OVERVIEW"`
+	Template            string `mapstructure:"NOTIFIER_TEMPLATE"`
+	CustomTemplate      string `mapstructure:"CUSTOM_TEMPLATE"`
+	SuppressHashChanges bool   `mapstructure:"SUPPRESS_HASH_CHANGES"`
 }
 
 // Init will create default NotifierConfig with following priority

--- a/data/cdk-diff-resources-changes.log
+++ b/data/cdk-diff-resources-changes.log
@@ -17,7 +17,7 @@ Resources
         [ ] ],
         [ ] "Essential": true,
         [ ] "Image": {
--       [-]   "Fn::Sub": "123456789012.dkr.ecr.eu-central-1.${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-eu-central-1:88f53e8e790ee348fe371bgt2dd7365d2cc15be096da0c12d4b0d8bf47aff35d3"
+-       [-]   "Fn::Sub": "123456789012.dkr.ecr.eu-central-1.${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-eu-central-1:88f53e8e790ee348fe371bfe2dd7365d2cc15be096da0c12d4b0d8bf47aff35d3"
 +       [+]   "Fn::Sub": "123456789012.dkr.ecr.eu-central-1.${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-eu-central-1:64137e051d225c2e197f36cf11456f21c0ec449c2902fa5c8d685e0fbbe822e2d"
         [ ] },
         [ ] "LogConfiguration": {


### PR DESCRIPTION
* suppress hash changes when activated
* added cli arg `--suppress-hash-changes`
* we suppress if the number of lines with hashes is equal to the number of total diff
* the hash must be 64 or 65 characters long and in hexadecimal format to be detected
* this is experimental, it's possible that you unintentionally skip on changes

closes #125 