### PR TITLE
Per VCS max comment length

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,6 +98,7 @@ func init() {
 	rootCmd.Flags().StringP("user", "u", "", "Optional set username for token (required for bitbucket)")
 	rootCmd.Flags().String("gitlab-url", "https://gitlab.com/", "Optional set gitlab url")
 	rootCmd.Flags().String("github-host", "", "Optional set host for GitHub Enterprise")
+	rootCmd.Flags().Int("github-max-comment-length", 0, "Optional set max comment length for GitHub Enterprise")
 	rootCmd.Flags().Bool("no-post-mode", false, "Optional do not post comment to VCS, instead write additional file and print diff to stdout")
 	rootCmd.Flags().Bool("disable-collapse", false, "Collapsible comments are enabled by default for GitHub and GitLab. When set to true it will not use collapsed sections.")
 	rootCmd.Flags().Bool("show-overview", false, "[Deprected: use template extended instead] Show Overview are disabled by default. When set to true it will show the number of cdk stacks with diff and  the number of replaced resources in the overview section.")
@@ -125,6 +126,7 @@ func init() {
 	viperMappings["CI_SYSTEM"] = "ci"
 	viperMappings["URL"] = "gitlab-url"
 	viperMappings["GITHUB_ENTERPRISE_HOST"] = "github-host"
+	viperMappings["GITHUB_ENTERPRISE_MAX_COMMENT_LENGTH"] = "github-max-comment-length"
 	viperMappings["SUPPRESS_HASH_CHANGES"] = "suppress-hash-changes"
 
 	for k, v := range viperMappings {

--- a/config/app.go
+++ b/config/app.go
@@ -115,20 +115,21 @@ const (
 
 // NotifierConfig holds configuration
 type NotifierConfig struct {
-	LogFile         string `mapstructure:"LOG_FILE"`
-	TagID           string `mapstructure:"TAG_ID"`
-	RepoName        string `mapstructure:"REPO_NAME"`
-	RepoOwner       string `mapstructure:"REPO_OWNER"`
-	Token           string `mapstructure:"TOKEN"`
-	TokenUser       string `mapstructure:"TOKEN_USER"`
-	PullRequestID   int    `mapstructure:"PR_ID"`
-	DeleteComment   bool   `mapstructure:"DELETE_COMMENT"`
-	Vcs             string `mapstructure:"VERSION_CONTROL_SYSTEM"`
-	Ci              string `mapstructure:"CI_SYSTEM"`
-	Url             string `mapstructure:"URL"`
-	GithubHost      string `mapstructure:"GITHUB_ENTERPRISE_HOST"`
-	NoPostMode      bool   `mapstructure:"NO_POST_MODE"`
-	DisableCollapse bool   `mapstructure:"DISABLE_COLLAPSE"`
+	LogFile                string `mapstructure:"LOG_FILE"`
+	TagID                  string `mapstructure:"TAG_ID"`
+	RepoName               string `mapstructure:"REPO_NAME"`
+	RepoOwner              string `mapstructure:"REPO_OWNER"`
+	Token                  string `mapstructure:"TOKEN"`
+	TokenUser              string `mapstructure:"TOKEN_USER"`
+	PullRequestID          int    `mapstructure:"PR_ID"`
+	DeleteComment          bool   `mapstructure:"DELETE_COMMENT"`
+	Vcs                    string `mapstructure:"VERSION_CONTROL_SYSTEM"`
+	Ci                     string `mapstructure:"CI_SYSTEM"`
+	Url                    string `mapstructure:"URL"`
+	GithubHost             string `mapstructure:"GITHUB_ENTERPRISE_HOST"`
+	GithubMaxCommentLength int    `mapstructure:"GITHUB_ENTERPRISE_MAX_COMMENT_LENGTH"`
+	NoPostMode             bool   `mapstructure:"NO_POST_MODE"`
+	DisableCollapse        bool   `mapstructure:"DISABLE_COLLAPSE"`
 	// TODO deprecated
 	ShowOverview        bool   `mapstructure:"SHOW_OVERVIEW"`
 	Template            string `mapstructure:"NOTIFIER_TEMPLATE"`

--- a/provider/bitbucket.go
+++ b/provider/bitbucket.go
@@ -3,9 +3,14 @@ package provider
 import (
 	"context"
 	"errors"
+
 	"github.com/karlderkaefer/cdk-notifier/config"
 	"github.com/sirupsen/logrus"
 )
+
+// maxCommentLength is the maximum number of chars allowed by Bitbucket in a
+// single comment.
+const BitbucketMaxCommentLength = 32768
 
 var (
 	errContentEmpty = errors.New("comment content should not be empty")

--- a/provider/github.go
+++ b/provider/github.go
@@ -2,14 +2,18 @@ package provider
 
 import (
 	"context"
-	"fmt"
 	"errors"
+	"fmt"
 
 	"github.com/google/go-github/v53/github"
 	"github.com/karlderkaefer/cdk-notifier/config"
-	"golang.org/x/oauth2"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
 )
+
+// maxCommentLength is the maximum number of chars allowed in a single comment
+// by GitHub.
+const GithubMaxCommentLength = 65536
 
 // GithubIssuesService interface for required GitHub actions with API
 type GithubIssuesService interface {

--- a/provider/gitlab.go
+++ b/provider/gitlab.go
@@ -8,6 +8,10 @@ import (
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
+// gitlabMaxCommentLength is the maximum number of chars allowed by Gitlab in a
+// single comment.
+const GitlabMaxCommentLength = 1000000
+
 // NotesService interface for required Gitlab actions with API
 type GitlabNotesService interface {
 	ListMergeRequestNotes(pid interface{}, mergeRequest int, opt *gitlab.ListMergeRequestNotesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Note, *gitlab.Response, error)


### PR DESCRIPTION
## What
Per VCS max comment length plus optional override for GHE.

## Why
Different VCS have different max comment lengths and GHE can set arbitrary (read: defaults to 65536 as github.com but can be increased)

Instead of https://github.com/karlderkaefer/cdk-notifier/pull/146

## Testing
![image](https://github.com/karlderkaefer/cdk-notifier/assets/3025844/4c6b1bf1-b977-41a5-b757-f069977cbaa3)
