### PR TITLE
fix: arm64 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,11 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 # Leverage a cache mount to /go/pkg/mod/ to speed up subsequent builds.
 # Leverage a bind mount to the current directory to avoid having to copy the
 # source code into the container.
+ARG TARGETOS 
+ARG TARGETARCH
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=bind,target=. \
-    CGO_ENABLED=0 go build -o /bin/cdk-notifier .
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /bin/cdk-notifier .
 
 ################################################################################
 # Create a new stage for running the application that contains the minimal
@@ -41,12 +43,11 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 # most recent version of that image when you build your Dockerfile. If
 # reproducability is important, consider using a versioned tag
 # (e.g., alpine:3.17.2) or SHA (e.g., alpine:sha256:c41ab5c992deb4fe7e5da09f67a8804a46bd0592bfdf0b1847dde0e0889d2bff).
-FROM --platform=$BUILDPLATFORM alpine:latest AS final
+FROM --platform=$TARGETPLATFORM alpine:latest AS final
 
 # Install any runtime dependencies that are needed to run your application.
 # Leverage a cache mount to /var/cache/apk/ to speed up subsequent builds.
-RUN --mount=type=cache,target=/var/cache/apk \
-    apk --update add \
+RUN apk --update add \
         ca-certificates \
         tzdata \
         && \


### PR DESCRIPTION
adjusting cross compile settings for multi platform docker image according to guide
https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/

this was testing sucessfully on emulated docker environment: 
```
docker buildx create --name mybuilder --use
docker buildx build --platform linux/amd64,linux/arm64 -t karlderkaefer/cdk-test:v1 --push .
docker run --rm --platform linux/arm64 karlderkaefer/cdk-test:v1 --help
```

closes #160
