### PR TITLE
chore: use minimum release days and digest sha for action

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,13 @@
 {
   "extends": [
     "github>karlderkaefer/renovate-config:golang",
-    "schedule:monthly"
+    "schedule:monthly",
+    "helpers:pinGitHubActionDigests"
   ],
   "packageRules": [
+    {
+      "minimumReleaseAge": "7 days"
+    },
     {
       "matchUpdateTypes": [
         "major"


### PR DESCRIPTION
harden renovate config, use minimum release days of 7 and pin actions to sha1